### PR TITLE
Could com.wdbyte.core-java-modules:core-java-io:1.0.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/core-java-modules/core-java-io/pom.xml
+++ b/core-java-modules/core-java-io/pom.xml
@@ -18,4 +18,14 @@
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>31.0.1-jre</version>
+            <type>jar</type>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
 </project>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/78527112/163816593-88c9d5aa-ee06-4faf-a765-a003ddbbc1ef.png)
This figure presents the dependency tree between multiple modules in **_core-java-modules_**. As shown in this figure, Libraries 
##
com.google.code.findbugs:jsr305:jar:3.0.2:compile
com.google.guava:guava:jar:31.0.1-jre:compile
com.google.guava:failureaccess:jar:1.0.1:compile
com.google.errorprone:error_prone_annotations:jar:2.7.1:compile
com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
org.checkerframework:checker-qual:jar:3.12.0:compile
com.google.j2objc:j2objc-annotations:jar:1.3:compile
## Outdated dependencies
com.google.j2objc:j2objc-annotations:1.3 (**_2382_** days without maintenance)
com.google.guava:failureaccess:1.0.1 (**_1712_** days without maintenance)

---
in module **_core-java-performance, core-java-8, core-java-9, core-java-performance-code, core-java-io, core-java-string_** is inherited from their parent module. However, it is not used by module **_core-java-io_**. We can perform refactoring operations in the pom, by removing such redundant dependencies in module **_core-java-io_**.

Specifically, the scope of **_com.google.guava:guava_** in **_core-java-io_** can be changed from **_compile_** to **_provided_**.  The revisions in the pom are described as follows:
![image](https://user-images.githubusercontent.com/78527112/163817423-1dfc897b-9ffb-4168-8712-fdbc07747f4d.png)

